### PR TITLE
links does not work without dots

### DIFF
--- a/View/layout.phtml
+++ b/View/layout.phtml
@@ -8,9 +8,9 @@
 </head>
 <body>
     
-    <a href="/index.php">Home</a>
-    <a href="/index.php?controller=book&action=index">Books</a>
-    <a href="/index.php?controller=default&action=feedback">Contact us</a>
+    <a href="./index.php">Home</a>
+    <a href="./index.php?controller=book&action=index">Books</a>
+    <a href="./index.php?controller=default&action=feedback">Contact us</a>
     
     <hr>
     


### PR DESCRIPTION
Я уже привык добавлять точки к ссылкам когда скачиваю у тебя очередной код с урока. Потому что когда открываю этот код - там не работают ссылки, хотя на паре всё работает. Видать другая версия php. Предполагаю что ссылки с точками будут работать в любой версии и поэтому следует писать так.